### PR TITLE
Thanh login refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ flutter_*.png
 linked_*.ds
 unlinked.ds
 unlinked_spec.ds
+.fvm
 
 # Android related
 **/android/**/gradle-wrapper.jar
@@ -74,6 +75,7 @@ unlinked_spec.ds
 **/android/key.properties
 *.jks
 local.properties
+**/android/app/
 
 # iOS/XCode related
 **/ios/**/*.mode1v3

--- a/lib/auth/auth_repository.dart
+++ b/lib/auth/auth_repository.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:take_home_marv/constants/api_endpoints.dart'
     show AuthApiEndpoints;
 import 'package:take_home_marv/models/user_model.dart';
+import 'package:take_home_marv/utils/validator_helper.dart';
 import 'package:take_home_marv/services/token_service.dart';
 import 'package:take_home_marv/services/api_service.dart';
 import 'package:take_home_marv/enums/auth_enums.dart';
@@ -14,6 +15,9 @@ class AuthRepository {
   // Login to app
   Future<User> login(String email, String password) async {
     try {
+      ValidatorHelper.validateEmail(email);
+      ValidatorHelper.validatePassword(password);
+
       // First request OAuth token
       await TokenService.requestOAuthToken().then((tokenData) async {
         await TokenService.setAccessToken(
@@ -24,18 +28,6 @@ class AuthRepository {
         await TokenService.setTokenExpire(tokenData['expires_in']);
       });
 
-      // Simple validation (should be in a separate validator class)
-      if (email.isEmpty || password.isEmpty) {
-        throw Exception('Email and password cannot be empty');
-      }
-
-      if (!email.contains('@')) {
-        throw Exception('Please enter a valid email');
-      }
-
-      if (password.length < 6) {
-        throw Exception('Password must be at least 6 characters');
-      }
 
       // Mock API call with our service
       final response = await _apiService.post(

--- a/lib/auth/auth_repository.dart
+++ b/lib/auth/auth_repository.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:take_home_marv/constants/api_endpoints.dart'
+    show AuthApiEndpoints;
 import 'package:take_home_marv/models/user_model.dart';
 import 'package:take_home_marv/services/token_service.dart';
 import 'package:take_home_marv/services/api_service.dart';
@@ -36,7 +38,7 @@ class AuthRepository {
 
       // Mock API call with our service
       final response = await _apiService.post(
-        'login',
+        AuthApiEndpoints.login,
         data: {
           'email': email,
           'password': password,
@@ -77,7 +79,7 @@ class AuthRepository {
   Future<void> logout() async {
     try {
       // Make a logout API call
-      await _apiService.post('logout');
+      await _apiService.post(AuthApiEndpoints.logout);
 
       // Clear local storage
       final prefs = await SharedPreferences.getInstance();
@@ -110,7 +112,7 @@ class AuthRepository {
 
       // In a real app, we would fetch the latest user data from the API
       // Here we're just returning the cached user
-      final response = await _apiService.get('user/profile');
+      final response = await _apiService.get(AuthApiEndpoints.userProfile);
 
       if (!response.success) {
         throw Exception(

--- a/lib/auth/auth_repository.dart
+++ b/lib/auth/auth_repository.dart
@@ -12,7 +12,10 @@ class AuthRepository {
   final ApiService _apiService;
   final TokenService _tokenService;
   final SharedPreferences _sharedPrefs;
+
   static const String _userKey = 'current_user';
+  static const String _clientId = '1';
+  static const String _clientSecret = 'mock_client_secret';
 
   AuthRepository(
     this._apiService,
@@ -26,16 +29,7 @@ class AuthRepository {
       ValidatorHelper.validateEmail(email);
       ValidatorHelper.validatePassword(password);
 
-      // First request OAuth token
-      await TokenService.requestOAuthToken().then((tokenData) async {
-        await TokenService.setAccessToken(
-          tokenData['access_token'],
-          TokenType.user,
-        );
-        await TokenService.setRefreshToken(tokenData['refresh_token']);
-        await TokenService.setTokenExpire(tokenData['expires_in']);
-      });
-
+      await requestOAuthToken();
 
       // Mock API call with our service
       final response = await _apiService.post(
@@ -46,26 +40,23 @@ class AuthRepository {
         },
       );
 
-      if (response.success) {
-        // In a real app, the user would come from the response
-        // Here we're creating a mock user
-        final user = User(
-          id: '1',
-          email: email,
-          firstName: 'Test',
-          lastName: 'User',
-          emailVerified: true,
-        );
-
-        // Save the user in SharedPreferences
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setString(_userKey, jsonEncode(user.toJson()));
-
-        return user;
-      } else {
+      if (!response.success) {
         throw Exception(response.errors?.join(', ') ?? 'Login failed');
       }
+
+      // In a real app, the user would come from the response
+      // Here we're creating a mock user
+      final user = User(
+        id: '1',
+        email: email,
+        firstName: 'Test',
+        lastName: 'User',
+        emailVerified: true,
+      );
+
+      // Save the user in SharedPreferences
       await _sharedPrefs.setString(_userKey, jsonEncode(user.toJson()));
+      return user;
     } catch (e) {
       throw Exception('Login failed: ${e.toString()}');
     }
@@ -82,18 +73,14 @@ class AuthRepository {
     try {
       // Make a logout API call
       await _apiService.post(AuthApiEndpoints.logout);
-
-      // Clear local storage
-      await _sharedPrefs.remove(_userKey);
-      await _tokenService.removeTokenData();
     } catch (e) {
-      // Even if API call fails, clear local data
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(_userKey);
-      await _tokenService.removeTokenData();
-
+      // TODO: better to log out error here
       throw Exception('Logout failed: ${e.toString()}');
     }
+
+    // Clear local storage
+    await _sharedPrefs.remove(_userKey);
+    await _tokenService.removeTokenData();
   }
 
   Future<User> getCurrentUser() async {
@@ -122,6 +109,62 @@ class AuthRepository {
       return User.fromJson(jsonDecode(userJson));
     } catch (e) {
       throw Exception('Failed to get current user: ${e.toString()}');
+    }
+  }
+
+  // Mock method to simulate requesting an OAuth token
+  Future<AccessToken> requestOAuthToken() async {
+    // Simulating network delay
+    await Future.delayed(const Duration(milliseconds: 500));
+
+    final mockTokenJson = {
+      'access_token':
+          'mock_access_token_${DateTime.now().millisecondsSinceEpoch}',
+      'refresh_token':
+          'mock_refresh_token_${DateTime.now().millisecondsSinceEpoch}',
+      'expires_in': 3600, // 1 hour
+      'token_type': 'bearer',
+    };
+
+    final token = AccessToken.fromJson(mockTokenJson);
+    await _tokenService.setAccessToken(token, TokenType.user);
+    return token;
+  }
+
+  Future<void> refreshTokenIfNeeded() async {
+    final isExpired = await _tokenService.isTokenExpired();
+    if (isExpired) {
+      await _refreshToken();
+    }
+  }
+
+  Future<void> _refreshToken() async {
+    try {
+      final storedToken = _tokenService.getStoredAccessToken();
+      if (storedToken?.refreshToken == null) {
+        await logout();
+        return;
+      }
+
+      final response = await _apiService.post(
+        AuthApiEndpoints.tokenRequest,
+        data: {
+          'grant_type': 'refresh_token',
+          'client_id': _clientId,
+          'client_secret': _clientSecret,
+          'refresh_token': storedToken!.refreshToken,
+        },
+      );
+
+      if (!response.success) {
+        throw Exception(
+            response.errors?.join(', ') ?? 'Failed to refresh token');
+      }
+
+      final newToken = AccessToken.fromJson(response.data);
+      await _tokenService.setAccessToken(newToken, TokenType.user);
+    } catch (e) {
+      throw Exception('Failed to get OAuthToken');
     }
   }
 }

--- a/lib/auth/auth_repository.dart
+++ b/lib/auth/auth_repository.dart
@@ -9,8 +9,16 @@ import 'package:take_home_marv/services/api_service.dart';
 import 'package:take_home_marv/enums/auth_enums.dart';
 
 class AuthRepository {
-  final ApiService _apiService = ApiService();
+  final ApiService _apiService;
+  final TokenService _tokenService;
+  final SharedPreferences _sharedPrefs;
   static const String _userKey = 'current_user';
+
+  AuthRepository(
+    this._apiService,
+    this._tokenService,
+    this._sharedPrefs,
+  );
 
   // Login to app
   Future<User> login(String email, String password) async {
@@ -57,14 +65,15 @@ class AuthRepository {
       } else {
         throw Exception(response.errors?.join(', ') ?? 'Login failed');
       }
+      await _sharedPrefs.setString(_userKey, jsonEncode(user.toJson()));
     } catch (e) {
       throw Exception('Login failed: ${e.toString()}');
     }
   }
 
   Future<bool> isLoggedIn() async {
-    final tokenType = await TokenService.currentTokenType();
-    final isExpired = await TokenService.isTokenExpired();
+    final tokenType = await _tokenService.currentTokenType();
+    final isExpired = await _tokenService.isTokenExpired();
 
     return tokenType == TokenType.user && !isExpired;
   }
@@ -75,14 +84,13 @@ class AuthRepository {
       await _apiService.post(AuthApiEndpoints.logout);
 
       // Clear local storage
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(_userKey);
-      await TokenService.removeTokenData();
+      await _sharedPrefs.remove(_userKey);
+      await _tokenService.removeTokenData();
     } catch (e) {
       // Even if API call fails, clear local data
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(_userKey);
-      await TokenService.removeTokenData();
+      await _tokenService.removeTokenData();
 
       throw Exception('Logout failed: ${e.toString()}');
     }
@@ -90,8 +98,7 @@ class AuthRepository {
 
   Future<User> getCurrentUser() async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final userJson = prefs.getString(_userKey);
+      final userJson = _sharedPrefs.getString(_userKey);
 
       if (userJson == null) {
         throw Exception('User not found');

--- a/lib/auth/auth_repository.dart
+++ b/lib/auth/auth_repository.dart
@@ -5,6 +5,7 @@ import 'package:take_home_marv/constants/api_endpoints.dart'
 import 'package:take_home_marv/models/user_model.dart';
 import 'package:take_home_marv/services/token_service.dart';
 import 'package:take_home_marv/services/api_service.dart';
+import 'package:take_home_marv/enums/auth_enums.dart';
 
 class AuthRepository {
   final ApiService _apiService = ApiService();

--- a/lib/constants/api_endpoints.dart
+++ b/lib/constants/api_endpoints.dart
@@ -1,4 +1,5 @@
 class AuthApiEndpoints {
+  static const String baseUrl = 'https://mockapiurl.com/api';
   static const String login = 'login';
   static const String logout = 'logout';
   static const String userProfile = 'user/profile';

--- a/lib/constants/api_endpoints.dart
+++ b/lib/constants/api_endpoints.dart
@@ -1,0 +1,5 @@
+class AuthApiEndpoints {
+  static const String login = 'login';
+  static const String logout = 'logout';
+  static const String userProfile = 'user/profile';
+}

--- a/lib/constants/api_endpoints.dart
+++ b/lib/constants/api_endpoints.dart
@@ -1,5 +1,6 @@
 class AuthApiEndpoints {
   static const String baseUrl = 'https://mockapiurl.com/api';
+  static const String tokenRequest = 'oauth/token';
   static const String login = 'login';
   static const String logout = 'logout';
   static const String userProfile = 'user/profile';

--- a/lib/enums/auth_enums.dart
+++ b/lib/enums/auth_enums.dart
@@ -1,0 +1,14 @@
+enum TokenType {
+  user,
+  api,
+  none;
+
+  const TokenType();
+
+  static TokenType fromString(String? stringTokenType) {
+    return TokenType.values.firstWhere(
+      (e) => e.name == (stringTokenType ?? 'none'),
+      orElse: () => TokenType.none,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,31 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:take_home_marv/utils/locator.dart';
 import 'auth/auth_repository.dart';
 import 'auth/cubit/auth_cubit.dart';
 import 'auth/cubit/auth_state.dart';
 import 'pages/login_page.dart';
 import 'pages/success_page.dart';
 
-void main() {
-  runApp(MyApp());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await setupLocator(); //
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  final AuthRepository authRepository = AuthRepository();
-
-  MyApp({super.key});
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Login Refactor Test',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
-        useMaterial3: true,
-      ),
-      home: BlocProvider(
-        create: (context) => AuthCubit(authRepository),
-        child: BlocBuilder<AuthCubit, AuthState>(
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(
+          create: (context) => AuthCubit(getIt<AuthRepository>()),
+        ),
+      ],
+      child: MaterialApp(
+        title: 'Login Refactor Test',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
+          useMaterial3: true,
+        ),
+        home: BlocBuilder<AuthCubit, AuthState>(
           builder: (context, state) {
             if (state is AuthorizedState) {
               return const SuccessPage();

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:take_home_marv/constants/api_endpoints.dart'
+    show AuthApiEndpoints;
 import 'package:take_home_marv/services/token_service.dart';
 
 class ApiResponse {
@@ -80,7 +82,7 @@ class ApiService {
   // Mock data generator based on endpoint
   dynamic _getMockData(String endpoint) {
     switch (endpoint) {
-      case 'login':
+      case AuthApiEndpoints.login:
         return {
           'user': {
             'id': '1',
@@ -93,7 +95,7 @@ class ApiService {
           'refresh_token': 'mock_refresh_token',
           'expires_in': 3600,
         };
-      case 'user/profile':
+      case AuthApiEndpoints.userProfile:
         return {
           'id': '1',
           'email': 'test@example.com',

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:take_home_marv/constants/api_endpoints.dart'
     show AuthApiEndpoints;
+import 'package:take_home_marv/enums/auth_enums.dart';
 import 'package:take_home_marv/services/token_service.dart';
 
 class ApiResponse {

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -2,8 +2,6 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:take_home_marv/constants/api_endpoints.dart'
     show AuthApiEndpoints;
-import 'package:take_home_marv/enums/auth_enums.dart';
-import 'package:take_home_marv/services/token_service.dart';
 
 class ApiResponse {
   final bool success;
@@ -44,7 +42,10 @@ class ApiResponse {
 }
 
 class ApiService {
-  static const String baseUrl = 'https://mockapiurl.com/api';
+  // allow using same service to different APIs with different base urls
+  final String _baseUrl;
+
+  ApiService(this._baseUrl);
 
   // GET request
   Future<ApiResponse> get(String endpoint,
@@ -122,28 +123,6 @@ class ApiService {
           ['Failed to parse response: ${response.statusCode}'],
         );
       }
-    }
-  }
-
-  // Refresh token handling
-  Future<void> _handleTokenRefresh() async {
-    try {
-      final refreshToken = await TokenService.getRefreshToken();
-      if (refreshToken == null) {
-        return;
-      }
-
-      // Mock refresh token response
-      final tokenData = await TokenService.requestOAuthToken();
-
-      await TokenService.setAccessToken(
-        tokenData['access_token'],
-        TokenType.user,
-      );
-      await TokenService.setRefreshToken(tokenData['refresh_token']);
-      await TokenService.setTokenExpire(tokenData['expires_in']);
-    } catch (e) {
-      print('Failed to refresh token: $e');
     }
   }
 }

--- a/lib/services/token_service.dart
+++ b/lib/services/token_service.dart
@@ -1,30 +1,5 @@
 import 'package:shared_preferences/shared_preferences.dart';
-
-enum TokenType { user, api, none }
-
-extension TokenTypeExtension on TokenType {
-  String get stringRepresentation {
-    switch (this) {
-      case TokenType.user:
-        return 'user';
-      case TokenType.api:
-        return 'api';
-      default:
-        return 'none';
-    }
-  }
-
-  static TokenType fromString(String? stringTokenType) {
-    switch (stringTokenType ?? "") {
-      case 'user':
-        return TokenType.user;
-      case 'api':
-        return TokenType.api;
-      default:
-        return TokenType.none;
-    }
-  }
-}
+import 'package:take_home_marv/enums/auth_enums.dart';
 
 class TokenService {
   static const String _accessTokenKey = 'access_token';
@@ -47,7 +22,7 @@ class TokenService {
   ) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_accessTokenKey, token ?? '');
-    await prefs.setString(_tokenTypeKey, tokenType.stringRepresentation);
+    await prefs.setString(_tokenTypeKey, tokenType.name);
   }
 
   static Future<String?> getRefreshToken() async {
@@ -82,7 +57,7 @@ class TokenService {
   static Future<TokenType> currentTokenType() async {
     final prefs = await SharedPreferences.getInstance();
     final stringTokenType = prefs.getString(_tokenTypeKey);
-    return TokenTypeExtension.fromString(stringTokenType);
+    return TokenType.fromString(stringTokenType);
   }
 
   static Future<bool> removeTokenData() async {

--- a/lib/services/token_service.dart
+++ b/lib/services/token_service.dart
@@ -1,7 +1,34 @@
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:take_home_marv/enums/auth_enums.dart';
 
+class AccessToken {
+  final String? accessToken;
+  final String? refreshToken;
+  final int? expiresIn;
+  final int? tokenType;
+
+  const AccessToken({
+    this.accessToken,
+    this.refreshToken,
+    this.expiresIn,
+    this.tokenType,
+  });
+
+  factory AccessToken.fromJson(Map<String, dynamic> json) {
+    return AccessToken(
+      accessToken: json['access_token'],
+      refreshToken: json['refresh_token'],
+      expiresIn: json['expires_in'],
+      tokenType: json['token_type'],
+    );
+  }
+}
+
 class TokenService {
+  final SharedPreferences _sharedPrefs;
+
+  TokenService(this._sharedPrefs);
+
   static const String _accessTokenKey = 'access_token';
   static const String _tokenTypeKey = 'token_type';
   static const String _refreshTokenKey = 'refresh_token';
@@ -11,70 +38,60 @@ class TokenService {
   static const String _clientId = '1';
   static const String _clientSecret = 'mock_client_secret';
 
-  static Future<String?> getAccessToken() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(_accessTokenKey);
+  Future<String?> getAccessToken() async {
+    return _sharedPrefs.getString(_accessTokenKey);
   }
 
-  static Future<void> setAccessToken(
+  Future<void> setAccessToken(
     String? token,
     TokenType tokenType,
   ) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_accessTokenKey, token ?? '');
-    await prefs.setString(_tokenTypeKey, tokenType.name);
+    await _sharedPrefs.setString(_accessTokenKey, token ?? '');
+    await _sharedPrefs.setString(_tokenTypeKey, tokenType.name);
   }
 
-  static Future<String?> getRefreshToken() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getString(_refreshTokenKey);
+  Future<String?> getRefreshToken() async {
+    return _sharedPrefs.getString(_refreshTokenKey);
   }
 
-  static Future<void> setRefreshToken(String? token) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_refreshTokenKey, token ?? '');
+  Future<void> setRefreshToken(String? token) async {
+    await _sharedPrefs.setString(_refreshTokenKey, token ?? '');
   }
 
-  static Future<void> setTokenExpire(int expireInSeconds) async {
-    final prefs = await SharedPreferences.getInstance();
+  Future<void> setTokenExpire(int expireInSeconds) async {
     final expiryTime = DateTime.now()
         .add(Duration(seconds: expireInSeconds))
         .millisecondsSinceEpoch;
-    await prefs.setInt(_tokenExpireKey, expiryTime);
+    await _sharedPrefs.setInt(_tokenExpireKey, expiryTime);
   }
 
-  static Future<bool> isTokenExpired() async {
-    final prefs = await SharedPreferences.getInstance();
-    final expiryTime = prefs.getInt(_tokenExpireKey);
+  Future<bool> isTokenExpired() async {
+    final expiryTime = _sharedPrefs.getInt(_tokenExpireKey);
 
-    if (expiryTime == null) {
-      return true;
-    }
+    if (expiryTime == null) return true;
 
     return DateTime.now().millisecondsSinceEpoch > expiryTime;
   }
 
-  static Future<TokenType> currentTokenType() async {
-    final prefs = await SharedPreferences.getInstance();
-    final stringTokenType = prefs.getString(_tokenTypeKey);
+  Future<TokenType> currentTokenType() async {
+    final stringTokenType = _sharedPrefs.getString(_tokenTypeKey);
     return TokenType.fromString(stringTokenType);
   }
 
-  static Future<bool> removeTokenData() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_accessTokenKey);
-    await prefs.remove(_refreshTokenKey);
-    await prefs.remove(_tokenTypeKey);
-    await prefs.remove(_tokenExpireKey);
+  Future<bool> removeTokenData() async {
+    await _sharedPrefs.remove(_accessTokenKey);
+    await _sharedPrefs.remove(_refreshTokenKey);
+    await _sharedPrefs.remove(_tokenTypeKey);
+    await _sharedPrefs.remove(_tokenExpireKey);
     return true;
   }
 
   // Mock method to simulate requesting an OAuth token
-  static Future<Map<String, dynamic>> requestOAuthToken() async {
+  Future<AccessToken> requestOAuthToken() async {
     // Simulating network delay
     await Future.delayed(const Duration(milliseconds: 500));
 
-    return {
+    final mockTokenJson = {
       'access_token':
           'mock_access_token_${DateTime.now().millisecondsSinceEpoch}',
       'refresh_token':
@@ -82,5 +99,28 @@ class TokenService {
       'expires_in': 3600, // 1 hour
       'token_type': 'bearer',
     };
+    return AccessToken.fromJson(mockTokenJson);
+  }
+
+  // Refresh token handling
+  Future<void> _handleTokenRefresh() async {
+    try {
+      final refreshToken = await getRefreshToken();
+      if (refreshToken == null) {
+        return;
+      }
+
+      // Mock refresh token response
+      final tokenData = await requestOAuthToken();
+
+      await setAccessToken(
+        tokenData.accessToken,
+        TokenType.user,
+      );
+      await setRefreshToken(tokenData.refreshToken);
+      await setTokenExpire(tokenData.expiresIn ?? 0);
+    } catch (e) {
+      print('Failed to refresh token: $e');
+    }
   }
 }

--- a/lib/services/token_service.dart
+++ b/lib/services/token_service.dart
@@ -1,26 +1,45 @@
+import 'dart:convert';
+
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:take_home_marv/enums/auth_enums.dart';
 
 class AccessToken {
   final String? accessToken;
   final String? refreshToken;
-  final int? expiresIn;
-  final int? tokenType;
+  final int? expiresInSeconds;
+  final DateTime? expiresAt;
+  final String? tokenType;
 
   const AccessToken({
     this.accessToken,
     this.refreshToken,
-    this.expiresIn,
+    this.expiresInSeconds,
+    this.expiresAt,
     this.tokenType,
   });
 
   factory AccessToken.fromJson(Map<String, dynamic> json) {
+    final expiresInSeconds = json['expires_in'];
+    final expiresAt = json['expires_at'] != null
+        ? DateTime.fromMillisecondsSinceEpoch(json['expires_at'])
+        : DateTime.now().add(Duration(seconds: expiresInSeconds));
+
     return AccessToken(
       accessToken: json['access_token'],
       refreshToken: json['refresh_token'],
-      expiresIn: json['expires_in'],
+      expiresInSeconds: expiresInSeconds,
+      expiresAt: expiresAt,
       tokenType: json['token_type'],
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'access_token': accessToken,
+      'refresh_token': refreshToken,
+      'expires_at': expiresAt?.millisecondsSinceEpoch,
+      'token_type': tokenType,
+    };
   }
 }
 
@@ -29,48 +48,42 @@ class TokenService {
 
   TokenService(this._sharedPrefs);
 
-  static const String _accessTokenKey = 'access_token';
   static const String _tokenTypeKey = 'token_type';
-  static const String _refreshTokenKey = 'refresh_token';
-  static const String _tokenExpireKey = 'token_expire';
+  static const String _storedTokenKey = 'stored_token';
 
-  // Mock API credentials
-  static const String _clientId = '1';
-  static const String _clientSecret = 'mock_client_secret';
+  AccessToken? _cachedToken;
 
-  Future<String?> getAccessToken() async {
-    return _sharedPrefs.getString(_accessTokenKey);
+  AccessToken? getStoredAccessToken() {
+    if (_cachedToken != null) return _cachedToken;
+
+    final storedTokenString = _sharedPrefs.getString(_storedTokenKey);
+    if (storedTokenString == null) return null;
+
+    final token = AccessToken.fromJson(jsonDecode(storedTokenString));
+    _cachedToken = token;
+    return token;
   }
 
   Future<void> setAccessToken(
-    String? token,
+    AccessToken? token,
     TokenType tokenType,
   ) async {
-    await _sharedPrefs.setString(_accessTokenKey, token ?? '');
-    await _sharedPrefs.setString(_tokenTypeKey, tokenType.name);
-  }
+    _cachedToken = token;
 
-  Future<String?> getRefreshToken() async {
-    return _sharedPrefs.getString(_refreshTokenKey);
-  }
-
-  Future<void> setRefreshToken(String? token) async {
-    await _sharedPrefs.setString(_refreshTokenKey, token ?? '');
-  }
-
-  Future<void> setTokenExpire(int expireInSeconds) async {
-    final expiryTime = DateTime.now()
-        .add(Duration(seconds: expireInSeconds))
-        .millisecondsSinceEpoch;
-    await _sharedPrefs.setInt(_tokenExpireKey, expiryTime);
+    if (token != null) {
+      final jsonString = jsonEncode(token.toJson());
+      await _sharedPrefs.setString(_storedTokenKey, jsonString);
+      await _sharedPrefs.setString(_tokenTypeKey, tokenType.name);
+    }
   }
 
   Future<bool> isTokenExpired() async {
-    final expiryTime = _sharedPrefs.getInt(_tokenExpireKey);
+    final token = _cachedToken ?? getStoredAccessToken();
+    if (token == null || token.expiresAt == null) return true;
 
-    if (expiryTime == null) return true;
-
-    return DateTime.now().millisecondsSinceEpoch > expiryTime;
+    final now = DateTime.now();
+    final remainingTime = token.expiresAt!.difference(now).inMinutes;
+    return remainingTime <= 2;
   }
 
   Future<TokenType> currentTokenType() async {
@@ -79,48 +92,9 @@ class TokenService {
   }
 
   Future<bool> removeTokenData() async {
-    await _sharedPrefs.remove(_accessTokenKey);
-    await _sharedPrefs.remove(_refreshTokenKey);
+    _cachedToken = null;
+    await _sharedPrefs.remove(_storedTokenKey);
     await _sharedPrefs.remove(_tokenTypeKey);
-    await _sharedPrefs.remove(_tokenExpireKey);
     return true;
-  }
-
-  // Mock method to simulate requesting an OAuth token
-  Future<AccessToken> requestOAuthToken() async {
-    // Simulating network delay
-    await Future.delayed(const Duration(milliseconds: 500));
-
-    final mockTokenJson = {
-      'access_token':
-          'mock_access_token_${DateTime.now().millisecondsSinceEpoch}',
-      'refresh_token':
-          'mock_refresh_token_${DateTime.now().millisecondsSinceEpoch}',
-      'expires_in': 3600, // 1 hour
-      'token_type': 'bearer',
-    };
-    return AccessToken.fromJson(mockTokenJson);
-  }
-
-  // Refresh token handling
-  Future<void> _handleTokenRefresh() async {
-    try {
-      final refreshToken = await getRefreshToken();
-      if (refreshToken == null) {
-        return;
-      }
-
-      // Mock refresh token response
-      final tokenData = await requestOAuthToken();
-
-      await setAccessToken(
-        tokenData.accessToken,
-        TokenType.user,
-      );
-      await setRefreshToken(tokenData.refreshToken);
-      await setTokenExpire(tokenData.expiresIn ?? 0);
-    } catch (e) {
-      print('Failed to refresh token: $e');
-    }
   }
 }

--- a/lib/utils/locator.dart
+++ b/lib/utils/locator.dart
@@ -1,0 +1,25 @@
+import 'package:get_it/get_it.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:take_home_marv/auth/auth_repository.dart';
+import 'package:take_home_marv/constants/api_endpoints.dart';
+import 'package:take_home_marv/services/token_service.dart';
+import 'package:take_home_marv/services/api_service.dart';
+
+final getIt = GetIt.instance;
+
+Future<void> setupLocator() async {
+  final sharedPreferences = await SharedPreferences.getInstance();
+
+  getIt.registerSingleton<SharedPreferences>(sharedPreferences);
+
+  getIt.registerSingleton<TokenService>(
+      TokenService(getIt<SharedPreferences>()));
+
+  getIt.registerSingleton<AuthRepository>(
+    AuthRepository(
+      ApiService(AuthApiEndpoints.baseUrl),
+      getIt<TokenService>(),
+      getIt<SharedPreferences>(),
+    ),
+  );
+}

--- a/lib/utils/validator_helper.dart
+++ b/lib/utils/validator_helper.dart
@@ -1,0 +1,19 @@
+class ValidatorHelper {
+  static void validateEmail(String email) {
+    if (email.isEmpty) {
+      throw Exception('Email cannot be empty');
+    }
+    if (!email.contains('@')) {
+      throw Exception('Please enter a valid email');
+    }
+  }
+
+  static void validatePassword(String password) {
+    if (password.isEmpty) {
+      throw Exception('Password cannot be empty');
+    }
+    if (password.length < 6) {
+      throw Exception('Password must be at least 6 characters');
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   flutter_bloc: ^8.1.3
   shared_preferences: ^2.2.2
   http: ^1.1.2
+  get_it: ^8.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Create a separate folder/file for Constants and Enums to keep it them organized in one space instead of being spread out
- Extract email and password validations into its own ValidatorHelper class
- Refactor TokenService, ApiService, and AuthRepository with dependency injections to decouple the services.
- Set up GetIt for easy setting up and locating dependencies
- Refactor logic to request and refresh access token in AuthRepository